### PR TITLE
feat: improve indent - allow specifying size and style

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/todor-a/tidy-json"
 clap = { version = "4.0", features = ["derive"] }
 glob = "0.3"
 ignore = "0.4"
-serde_json = {version = "1.0", features = ["preserve_order"]}
+serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = "1.0"
 log = "0.4"
 env_logger = "0.11"
@@ -20,14 +20,14 @@ rayon = "1.5"
 colored = "2.0"
 rand = "0.8"
 anyhow = "1.0"
+serde = { version = "1.0.0", features = ["derive"] }
 
 [dev-dependencies]
-insta = {version = "1.39.0", features = ["json"]}
+insta = { version = "1.39.0", features = ["json"] }
 tempfile = "3.2"
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 rstest = "0.22.0"
-serde = {version = "1.0.0", features = ["derive"]}
 
 # The profile that 'cargo dist' will build with
 [profile.dist]
@@ -47,7 +47,12 @@ tap = "todor-a/homebrew-tap"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".tar.gz"
 # The archive format to use for non-windows builds (defaults .tar.xz)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ tidy-json **/*.json --write
 ```
 
 ## Options
-
 ```
 Usage: tidy-json [OPTIONS] <INCLUDE>...
 
@@ -27,13 +26,15 @@ Arguments:
   <INCLUDE>...  File patterns to process (e.g., *.json)
 
 Options:
-  -e, --exclude <EXCLUDE>  File patterns to exclude (e.g., *.json)
-  -w, --write              Write the sorted JSON back to the input files
-  -b, --backup             Create backups before modifying files
-  -d, --depth <DEPTH>      Specify how deep the sorting should go
-  -o, --order <ORDER>      Specify the sort order [default: asc] [possible values: asc, desc, rand]
-  -h, --help               Print help
-  -V, --version            Print version
+  -e, --exclude <EXCLUDE>            File patterns to exclude (e.g., *.json)
+  -w, --write                        Write the sorted JSON back to the input files
+  -b, --backup                       Create backups before modifying files
+  -d, --depth <DEPTH>                Specify how deep the sorting should go
+  -o, --order <ORDER>                Specify the sort order [default: asc] [possible values: asc, desc, rand]
+  -i, --indent <INDENT>              Specify the desired indent
+      --indent-style <INDENT_STYLE>  Specify the desired indent style [possible values: tabs, spaces]
+  -h, --help                         Print help
+  -V, --version                      Print version
 ```
 
 ## Example

--- a/src/files.rs
+++ b/src/files.rs
@@ -65,15 +65,16 @@ fn has_allowed_extension(path: &Path, allowed_extensions: &[Extension]) -> bool 
 }
 
 pub fn list_files(
-    include_patterns: Vec<PathBuf>,
-    exclude_patterns: Option<Vec<PathBuf>>,
+    include_patterns: &[PathBuf],
+    exclude_patterns: &Option<Vec<PathBuf>>,
     allowed_extensions: Vec<Extension>,
 ) -> Result<Vec<PathBuf>> {
     let mut walk = WalkBuilder::new(".");
     walk.hidden(true).ignore(true).git_global(true);
 
-    let include_patterns: Vec<Pattern> = create_patterns(include_patterns)?;
+    let include_patterns: Vec<Pattern> = create_patterns(include_patterns.to_vec())?;
     let exclude_patterns: Vec<Pattern> = exclude_patterns
+        .clone()
         .map(create_patterns)
         .transpose()?
         .unwrap_or_default();
@@ -158,12 +159,8 @@ mod tests {
         File::create(subdir.join("test4.json")).unwrap();
         File::create(subdir.join("test5.jsonc")).unwrap();
 
-        let files = list_files(
-            vec![PathBuf::from("**/*.json")],
-            None,
-            vec![Extension::Json],
-        )
-        .unwrap();
+        let files =
+            list_files(&[PathBuf::from("**/*.json")], &None, vec![Extension::Json]).unwrap();
 
         debug!("result {:?}, a {:?}", files, &temp_path.join("test1.json"));
 
@@ -181,8 +178,8 @@ mod tests {
         File::create(temp_path.join("bar.json")).unwrap();
 
         let files = list_files(
-            vec![PathBuf::from("./foo.json")],
-            Some(vec![PathBuf::from("./test2bar.json")]),
+            &[PathBuf::from("./foo.json")],
+            &Some(vec![PathBuf::from("./test2bar.json")]),
             vec![Extension::Json],
         )
         .unwrap();

--- a/tests/cli_indent.rs
+++ b/tests/cli_indent.rs
@@ -1,0 +1,80 @@
+use rstest::rstest;
+use std::path::PathBuf;
+
+use assert_cmd::prelude::*;
+use insta::{assert_debug_snapshot, assert_json_snapshot, with_settings};
+use tempfile::TempDir;
+
+pub mod common;
+
+pub fn setup_test_dir(content: &str) -> (TempDir, PathBuf) {
+    let temp_dir = common::setup_test_directory();
+    let temp_path = temp_dir.path();
+
+    let test_file_path = temp_path.join("sample.json");
+
+    common::create_file(&test_file_path, content);
+
+    (temp_dir, test_file_path)
+}
+
+#[test]
+fn test_does_not_affect_spaces_in_values() -> Result<(), Box<dyn std::error::Error>> {
+    let (temp_dir, test_file_path) = setup_test_dir(
+        r#"
+    {
+        "b": "foo",
+        "a": "1 2  3",
+        "c": 3
+    }
+    "#,
+    );
+
+    let mut cmd = common::run_cli("**/*.json", &["--write"], temp_dir.path());
+
+    let _ = cmd.assert().success().get_output().stdout.clone();
+
+    let content = common::get_snapshot_info(
+        test_file_path,
+        common::AssertFileContentOption::Sorted(true),
+    );
+
+    assert_debug_snapshot!(content);
+
+    Ok(())
+}
+
+#[rstest]
+#[case(&["--write"])]
+#[case(&["--write", "-i=5"])]
+#[case(&["--write", "-i=3", "--indent-style=tabs"])]
+#[case(&["--write", "-i=6", "--indent-style=spaces"])]
+fn test_applies_correct_indent(#[case] flags: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+    let (temp_dir, test_file_path) = setup_test_dir(
+        r#"
+    {
+        "b": "foo",
+        "a": "1 2  3",
+        "c": 3
+    }
+    "#,
+    );
+
+    let mut cmd = common::run_cli("**/*.json", flags, temp_dir.path());
+
+    let _ = cmd.assert().success().get_output().stdout.clone();
+
+    let content = common::get_snapshot_info(
+        test_file_path,
+        common::AssertFileContentOption::Sorted(true),
+    );
+
+    with_settings!({
+        description => flags.join(", "),
+    }, {
+        // todo: this is not resolving the indentation, find a way to do it
+        assert_json_snapshot!(content);
+    });
+
+    Ok(())
+}

--- a/tests/snapshots/cli_indent__applies_correct_indent-2.snap
+++ b/tests/snapshots/cli_indent__applies_correct_indent-2.snap
@@ -1,0 +1,13 @@
+---
+source: tests/cli_indent.rs
+description: "--write"
+expression: content
+---
+[
+  {
+    "a": "1 2  3",
+    "b": "foo",
+    "c": 3
+  },
+  "should be sorted"
+]

--- a/tests/snapshots/cli_indent__applies_correct_indent-3.snap
+++ b/tests/snapshots/cli_indent__applies_correct_indent-3.snap
@@ -1,0 +1,13 @@
+---
+source: tests/cli_indent.rs
+description: "--write, -i=6, --indent-style=spaces"
+expression: content
+---
+[
+  {
+    "a": "1 2  3",
+    "b": "foo",
+    "c": 3
+  },
+  "should be sorted"
+]

--- a/tests/snapshots/cli_indent__applies_correct_indent-4.snap
+++ b/tests/snapshots/cli_indent__applies_correct_indent-4.snap
@@ -1,0 +1,13 @@
+---
+source: tests/cli_indent.rs
+description: "--write, -i=3, --indent-style=tabs"
+expression: content
+---
+[
+  {
+    "a": "1 2  3",
+    "b": "foo",
+    "c": 3
+  },
+  "should be sorted"
+]

--- a/tests/snapshots/cli_indent__applies_correct_indent.snap
+++ b/tests/snapshots/cli_indent__applies_correct_indent.snap
@@ -1,0 +1,13 @@
+---
+source: tests/cli_indent.rs
+description: "--write, -i=5"
+expression: content
+---
+[
+  {
+    "a": "1 2  3",
+    "b": "foo",
+    "c": 3
+  },
+  "should be sorted"
+]

--- a/tests/snapshots/cli_indent__does_not_affect_spaces_in_values.snap
+++ b/tests/snapshots/cli_indent__does_not_affect_spaces_in_values.snap
@@ -1,0 +1,12 @@
+---
+source: tests/cli_indent.rs
+expression: content
+---
+(
+    Object {
+        "a": String("1 2  3"),
+        "b": String("foo"),
+        "c": Number(3),
+    },
+    "should be sorted",
+)


### PR DESCRIPTION
This improves the ability to correct and apply uniform indentation.

Two new flags are introduced: `--indent` and `--indent-style`. If neither is supplied, the indent will be extracted from each file.

Also a bug is fixed where the indent correction would change values that had more than two spaces.