### PR TITLE
bench: fix criterion 0.8 black_box deprecation

### DIFF
--- a/benches/sort_benchmark.rs
+++ b/benches/sort_benchmark.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use serde_json::Value;
+use std::hint::black_box;
 
 use tidy_json::sort::sort;
 use tidy_json::SortOrder;


### PR DESCRIPTION
Fixes the remaining failing check seen on Dependabot PR #75.

## Summary
- replace deprecated `criterion::black_box` with `std::hint::black_box` in benchmark code
- keeps benchmark behavior unchanged while making it compatible with criterion 0.8
- unblocks `Run Benchmarks` with `-D warnings`

## Context
Dependabot branches are not maintainer-writable in this repo (`maintainerCanModify=false`), so this fix is provided as a standalone PR to merge into `main`.